### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 
 on:
   push


### PR DESCRIPTION
Potential fix for [https://github.com/dromara/dongle/security/code-scanning/1](https://github.com/dromara/dongle/security/code-scanning/1)

To fix the problem, explicitly define the `permissions` key in the workflow file `.github/workflows/test.yml`. The least privilege required for this workflow appears to be reading repository contents, based on the jobs shown (checkout, testing, and uploading coverage to Codecov using a secret token). Therefore, add the following block at the root level of the workflow (just below the `name:` or above the `on:` key, but below `name:` is conventional):

```yaml
permissions:
  contents: read
```

This sets read-only access to repository contents for all jobs by default. If a job or step later needs more specific permissions (such as writing to issues or pull requests), those permissions can be added granularly at the job or workflow level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
